### PR TITLE
Minor fix missleading version recomendation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the gem to your `Gemfile`:
 ```ruby
 # Gemfile
 
-gem 'dredd-rack', '~> 0.4.0' # see semver.org
+gem 'dredd-rack', '~> 0.5.0' # see semver.org
 ```
 
 Define which application Dredd::Rack must serve automatically:


### PR DESCRIPTION
**As a** developer 
**In order to** use an up-to-date verison of Dredd::Rack 
**I want** the `README` to suggest me to install the most recent version available 