### PR TITLE
Add support for Dredd v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dredd::Rack
 [![Gem Version](https://badge.fury.io/rb/dredd-rack.svg)](http://badge.fury.io/rb/dredd-rack)
 [![Build Status](https://travis-ci.org/gonzalo-bulnes/dredd-rack.svg?branch=master)](https://travis-ci.org/gonzalo-bulnes/dredd-rack)
 [![Code Climate](https://codeclimate.com/github/gonzalo-bulnes/dredd-rack.svg)](https://codeclimate.com/github/gonzalo-bulnes/dredd-rack)
-[![Dredd Reference Version](https://img.shields.io/badge/dredd_reference_version-0.4.8-brightgreen.svg)](https://github.com/apiaryio/dredd)
+[![Dredd Reference Version](https://img.shields.io/badge/dredd_reference_version-1.0.0-brightgreen.svg)](https://github.com/apiaryio/dredd)
 [![Inline docs](http://inch-ci.org/github/gonzalo-bulnes/dredd-rack.svg?branch=master)](http://inch-ci.org/github/gonzalo-bulnes/dredd-rack)
 
 > **DISCLAIMER**: This is an early version of Dredd::Rack, please be aware that it will not be stable until `v1.0.0`. At any moment, [feedback][issues] is more than welcome! : ) -- [GB][gonzalo-bulnes]

--- a/doc/runner.md
+++ b/doc/runner.md
@@ -60,6 +60,11 @@ dredd = Dredd::Rack::Runner.new do |options|
 
   options.hookfiles 'doc/hooks/*_hooks.coffee'
 
+  options.language 'ruby'
+  options.server 'rails server'
+  options.server_wait '3'
+  options.custom 'a:b'
+
   options.only 'Machines > Machines Collection > List all Machines',
                'Machines > Machine > Retrieve a Machine'
 
@@ -78,7 +83,9 @@ dredd = Dredd::Rack::Runner.new do |options|
   options.method('POST').method('PUT')
 
   options.dry_run!            # no_dry_run!
+  options.sandbox!            # no_sandbox!
   options.names!              # no_names!
+  options.init!               # no_init!
   options.sorted!             # no_sorted!
   options.inline_errors!      # no_inline_errors!
   options.details!            # no_details!

--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -26,13 +26,13 @@ module Dredd
 
       undef_method :method
 
-      NEGATABLE_BOOLEAN_OPTIONS = [:dry_run!, :names!, :sorted!, :inline_errors!,
+      NEGATABLE_BOOLEAN_OPTIONS = [:dry_run!, :sandbox!, :names!, :init!, :sorted!, :inline_errors!,
                                    :details!, :color!, :timestamp!, :silent!]
       META_OPTIONS              = [:help, :version]
       BOOLEAN_OPTIONS           = NEGATABLE_BOOLEAN_OPTIONS + META_OPTIONS
 
-      SINGLE_ARGUMENT_OPTIONS   = [:hookfiles, :only, :reporter, :output, :header,
-                                   :user, :method, :level, :path]
+      SINGLE_ARGUMENT_OPTIONS   = [:hookfiles, :language, :server, :server_wait, :custom, :only,
+                                   :reporter, :output, :header, :user, :method, :level, :path]
       OPTIONS                   = BOOLEAN_OPTIONS + SINGLE_ARGUMENT_OPTIONS
 
       # Store the Dredd command line options

--- a/spec/lib/dredd/rack/runner_spec.rb
+++ b/spec/lib/dredd/rack/runner_spec.rb
@@ -214,15 +214,19 @@ describe Dredd::Rack::Runner do
     end
   end
 
-  Dredd::Rack::Runner::BOOLEAN_OPTIONS.each do |option|
+  Dredd::Rack::Runner::META_OPTIONS.each do |option|
     describe "##{option}", public: true do
       it_behaves_like 'a boolean option', option, ['some argument']
     end
   end
 
   Dredd::Rack::Runner::NEGATABLE_BOOLEAN_OPTIONS.each do |option|
+    describe "##{option}", public: true do
+      it_behaves_like 'a negatable boolean option', option.to_sym, ['some argument']
+    end
+
     describe "#no_#{option}", public: true do
-      it_behaves_like 'a boolean option', "no_#{option}".to_sym, ['some argument']
+      it_behaves_like 'a negatable boolean option', "no_#{option}".to_sym, ['some argument']
     end
   end
 

--- a/spec/support/specs_for_negatable_boolean_options.rb
+++ b/spec/support/specs_for_negatable_boolean_options.rb
@@ -1,0 +1,9 @@
+RSpec.shared_examples 'a negatable boolean option' do |option|
+
+  it_behaves_like 'an option', option
+  it_behaves_like 'a boolean option', option
+
+  it 'is ended by a bang (!)' do
+    expect(option[-1]).to eq '!'
+  end
+end


### PR DESCRIPTION
**As a** developer 
**In order to** be able to use the latest Dredd options (`--language`, `server`, and so on...) 
**I want** them to be supported by Dredd::Rack 

See https://github.com/apiaryio/dredd/tree/9d1daa5c7d4b