### PR TITLE
Throw exception when command is invalid

### DIFF
--- a/lib/dredd/rack.rb
+++ b/lib/dredd/rack.rb
@@ -2,6 +2,7 @@ require 'dredd/rack/configuration'
 require 'dredd/rack/rake_task'
 require 'dredd/rack/runner'
 require 'dredd/rack/version'
+require 'dredd/rack/errors'
 
 module Dredd
   module Rack

--- a/lib/dredd/rack/errors.rb
+++ b/lib/dredd/rack/errors.rb
@@ -1,0 +1,11 @@
+module Dredd
+  module Rack
+    class InvalidCommandError < Class.new(RuntimeError)
+      # InvalidCommandError = Class.new(RuntimeError)
+
+      def initialize(command)
+        super("Invalid command - #{command}")
+      end
+    end
+  end
+end

--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -96,7 +96,7 @@ module Dredd
           start_server! unless api_remote?
           Kernel.system(command)
         else
-          raise ArgumentError, "Invalid command - #{command}"
+          raise InvalidCommandError.new(command)
         end
       end
 

--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -92,10 +92,11 @@ module Dredd
       #
       # Returns true if the Dredd exit status is zero, false instead.
       def run
-
         if command_valid?
           start_server! unless api_remote?
           Kernel.system(command)
+        else
+          raise ArgumentError, "Invalid command - #{command}"
         end
       end
 

--- a/spec/lib/dredd/rack/runner_spec.rb
+++ b/spec/lib/dredd/rack/runner_spec.rb
@@ -173,7 +173,7 @@ describe Dredd::Rack::Runner do
       it 'fails with invalid command exception' do
         command = 'test_command'
         allow(subject).to receive(:command).and_return(command)
-        expect { subject.run }.to raise_error(ArgumentError, "Invalid command - #{command}")
+        expect { subject.run }.to raise_error(Dredd::Rack::InvalidCommandError, "Invalid command - #{command}")
       end
     end
     context 'when the command is valid' do

--- a/spec/lib/dredd/rack/runner_spec.rb
+++ b/spec/lib/dredd/rack/runner_spec.rb
@@ -164,6 +164,18 @@ describe Dredd::Rack::Runner do
 
   describe '#run', public: true do
 
+    context 'when command is not valid' do
+
+      before(:each) do
+        allow(subject).to receive(:command_valid?).and_return(false)
+      end
+
+      it 'fails with invalid command exception' do
+        command = 'test_command'
+        allow(subject).to receive(:command).and_return(command)
+        expect { subject.run }.to raise_error(ArgumentError, "Invalid command - #{command}")
+      end
+    end
     context 'when the command is valid' do
 
       before(:each) do


### PR DESCRIPTION
Hi,
I found it very confusing when using runner directly that it doesn't throw any exceptions and just fails silently when the command is not valid. I suggest that it should fail when command is not valid and print the command so that a user can fix it.