### PR TITLE
Allow single blueprint argument

### DIFF
--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -113,7 +113,7 @@ module Dredd
         end
 
         def command_valid?
-          command.has_at_least_two_arguments?
+          command.argument_count >= 2
         end
 
         def start_server!
@@ -147,16 +147,16 @@ end
 
 class String
 
-  # Verify that a command has at least two arguments (excluding options)
+  # Return the number of arguments in a command (excluding options)
   #
   # Examples:
   #
-  #    "dredd doc/*.apib http://api.example.com".valid? # => true
-  #    "dredd doc/*.apib doc/*apib.md http://api.example.com".valid? # => true
-  #    "dredd doc/*.apib http://api.example.com --level verbose".valid? # => true
-  #    "dredd http://api.example.com".valid? # => false
-  #    "dredd doc/*.apib --dry-run".valid? # => false
-  #    "dredd --dry-run --level verbose".valid? # => false
+  #    "dredd doc/*.apib http://api.example.com".argument_count # => 2
+  #    "dredd doc/*.apib doc/*apib.md http://api.example.com".argument_count # => 3
+  #    "dredd doc/*.apib http://api.example.com --level verbose".argument_count # => 2
+  #    "dredd http://api.example.com".argument_count # => 1
+  #    "dredd doc/*.apib --dry-run".argument_count # => 1
+  #    "dredd --dry-run --level verbose".argument_count # => 0
   #
   # Known limitations:
   #
@@ -165,16 +165,8 @@ class String
   #
   # Note:
   #
-  # The known limitations imply that there may be false negatives: this method
-  # can return false for commands that do have two arguments or more. But there
-  # should not be false positives: if the method returns true, then the command
-  # does have at least two arguments.
-  #
-  # Returns true if the command String has at least two arguments, false otherwise.
-  def has_at_least_two_arguments?
-    argument_count >= 2
-  end
-
+  # The known limitations imply that the count may be lower than (long options
+  # are not # counted) but never higher than the true number of arguments.
   def argument_count
     tokens = split('--').first.split(' ')
     arguments = tokens.length - 1

--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -113,7 +113,11 @@ module Dredd
         end
 
         def command_valid?
-          command.argument_count >= 2
+          if api_remote?
+            command.argument_count >= 2
+          else
+            command.argument_count >= 1
+          end
         end
 
         def start_server!

--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -172,7 +172,12 @@ class String
   #
   # Returns true if the command String has at least two arguments, false otherwise.
   def has_at_least_two_arguments?
-    split('--').first.split(' ').length >= 3
+    argument_count >= 2
+  end
+
+  def argument_count
+    tokens = split('--').first.split(' ')
+    arguments = tokens.length - 1
   end
 end
 

--- a/spec/lib/dredd/rack/runner_spec.rb
+++ b/spec/lib/dredd/rack/runner_spec.rb
@@ -77,7 +77,7 @@ describe Dredd::Rack::Runner do
     context 'when the generated command has less than two arguments' do
 
       it 'returns false' do
-        allow(subject).to receive_message_chain(:command, :has_at_least_two_arguments?).and_return(false)
+        allow(subject).to receive_message_chain(:command, :argument_count).and_return(0)
         expect(subject.send(:command_valid?)).not_to be_truthy
       end
     end
@@ -88,7 +88,7 @@ describe Dredd::Rack::Runner do
     context 'when the generated command has less than two arguments' do
 
       it 'executes a configration block in the context of the runner' do
-        allow(subject).to receive_message_chain(:command, :has_at_least_two_arguments?).and_return(false)
+        allow(subject).to receive_message_chain(:command, :argument_count).and_return(1)
 
         expect(subject).to receive_message_chain(:dry_run!, :color!)
         expect(subject).to receive(:level).with(:warning)
@@ -252,22 +252,22 @@ end
 
 describe String, public: true do
 
-  it 'responds to :has_at_least_two_arguments?' do
-    expect(subject).to respond_to :has_at_least_two_arguments?
+  it 'responds to :argument_count' do
+    expect(subject).to respond_to :argument_count
   end
 
 
-  describe '#has_at_least_two_arguments?' do
+  describe '#argument_count' do
 
     context 'when the String can be interpreted as a command with at least two arguments' do
-      context 'returns true (reliable)' do
+      context 'returns at least two' do
 
         ['dredd doc/*.apib http://api.example.com',
          'dredd doc/*.apib doc/*apib.md http://api.example.com',
          'dredd doc/*.apib http://api.example.com --level verbose'].each do |subject|
 
           it "e.g. '#{subject}'" do
-            expect(subject.has_at_least_two_arguments?).to be_truthy
+            expect(subject.argument_count).to be >= 2
           end
         end
       end
@@ -281,7 +281,7 @@ describe String, public: true do
          'dredd --dry-run --level verbose'].each do |subject|
 
           it "e.g. '#{subject}'" do
-            expect(subject.has_at_least_two_arguments?).to be_falsey
+            expect(subject.argument_count).to be < 2
           end
         end
       end

--- a/spec/lib/dredd/rack/runner_spec.rb
+++ b/spec/lib/dredd/rack/runner_spec.rb
@@ -75,10 +75,28 @@ describe Dredd::Rack::Runner do
   describe '#command_valid?', private: true do
 
     context 'when the generated command has less than two arguments' do
+      before do
+        allow(subject).to receive_message_chain(:command, :argument_count).and_return(1)
+      end
 
-      it 'returns false' do
-        allow(subject).to receive_message_chain(:command, :argument_count).and_return(0)
-        expect(subject.send(:command_valid?)).not_to be_truthy
+      context 'when the API is remote' do
+        before(:each) do
+          allow(subject).to receive(:api_remote?).and_return(true)
+        end
+
+        it 'returns false' do
+          expect(subject.send(:command_valid?)).not_to be_truthy
+        end
+      end
+
+      context 'when the API is local' do
+        before(:each) do
+          allow(subject).to receive(:api_remote?).and_return(false)
+        end
+
+        it 'returns false' do
+          expect(subject.send(:command_valid?)).to be_truthy
+        end
       end
     end
   end


### PR DESCRIPTION
@gonzalo-bulnes currently, one is unable to do the following:

```ruby
Dredd::Rack::RakeTask.new do |task|
  task.runner.configure do |dredd|
    dredd.paths_to_blueprints 'doc/*.apib'
  end
end
```

because the task exits early due to the # of arguments being checked _before_ we attempt to run the server (which has the side effect of adding an argument).

This is just a spike to get things working, so feel free to recommend a better solution. I tried my best to keep the documentation and tests up to date.