### PR TITLE
Fix missing quotes in Dredd command line arguments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    capybara (2.4.4)
+    capybara (2.5.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
@@ -23,15 +23,17 @@ GEM
       term-ansicolor
       yard (~> 0.8.7.5)
     method_source (0.8.2)
-    mime-types (2.4.3)
-    mini_portile (0.6.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    mime-types (3.0)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2015.1120)
+    mini_portile2 (2.0.0)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rack (1.6.0)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rainbow (2.0.0)

--- a/dredd-rack.gemspec
+++ b/dredd-rack.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["gon.bulnes@gmail.com"]
   gem.summary       = %q{Convenient API blueprint testing with Apiary Dredd for Rack applications.}
   gem.homepage      = "https://github.com/gonzalo-bulnes/dredd-rack"
-  gem.license         = "GPLv3"
+  gem.license         = "GPL-3.0+"
 
   gem.files = Dir["{doc,lib}/**/*", "Gemfile", "LICENSE", "Rakefile", "README.md"]
   gem.test_files = Dir["spec/**/*"]

--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -137,7 +137,7 @@ module Dredd
 
           option_flag = name.to_s.gsub('_', '-').gsub('!', '').prepend('--')
           command_parts = self.command_parts.push option_flag
-          command_parts = self.command_parts.push args.slice(0).to_s if SINGLE_ARGUMENT_OPTIONS.include? name
+          command_parts = self.command_parts.push args.slice(0).to_s.quote! if SINGLE_ARGUMENT_OPTIONS.include? name
           self
         end
 
@@ -173,6 +173,19 @@ class String
   # Returns true if the command String has at least two arguments, false otherwise.
   def has_at_least_two_arguments?
     split('--').first.split(' ').length >= 3
+  end
+
+  # Include quotes as part of the string
+  #
+  # Examples:
+  #
+  #    "Hello, world!".quote! # => "\"Hello, world!\""
+  #    "Hello, world!".size # => 13
+  #    "Hello, world!".quote!.size # => 15
+  #
+  # Returns a String, whose first and last characters are quotes.
+  def quote!
+    '"' + self + '"'
   end
 end
 

--- a/spec/lib/dredd/rack/runner_spec.rb
+++ b/spec/lib/dredd/rack/runner_spec.rb
@@ -123,7 +123,7 @@ describe Dredd::Rack::Runner do
 
         expect(subject.command).to match /http:\/\/localhost:4567/
         expect(subject.command).to match /blueprints\/\*\.apib doc\/\*\.apib/
-        expect(subject.command).to match /--level silly/
+        expect(subject.command).to match /--level "silly"/
         expect(subject.command).to match /--no-color/
 
         expect(subject.command).not_to match /http:\/\/localhost:3000/
@@ -256,6 +256,9 @@ describe String, public: true do
     expect(subject).to respond_to :has_at_least_two_arguments?
   end
 
+  it 'responds to :quote!' do
+    expect(subject).to respond_to :quote!
+  end
 
   describe '#has_at_least_two_arguments?' do
 
@@ -285,6 +288,16 @@ describe String, public: true do
           end
         end
       end
+    end
+  end
+
+  describe '#quote!' do
+
+    let(:string) { "some string" }
+
+    it 'returns the string content surrounded by quotes' do
+      expect(string.quote!).to match /some string/
+      expect(string.quote!).to match /^".*"$/
     end
   end
 end

--- a/spec/support/specs_for_single_argument_options.rb
+++ b/spec/support/specs_for_single_argument_options.rb
@@ -7,6 +7,14 @@ RSpec.shared_examples 'a single-argument option' do |option, args|
 
     expect{ subject.send(option, args.slice(0), args.slice(1)) }.to change{
       subject.command
-    }.to(end_with "#{option_flag} #{args.slice(0)}")
+    }.to(end_with "#{option_flag} \"#{args.slice(0)}\"")
+  end
+
+  it 'surrounds its flag argument with quotes' do
+    option_flag = option.to_s.gsub('_', '-').prepend('--')
+
+    expect{ subject.send(option, args.slice(0), args.slice(1)) }.to change{
+      subject.command
+    }.to(end_with "\"#{args.slice(0)}\"")
   end
 end


### PR DESCRIPTION
**As an** API developer 
**Given** an API blueprint with a section named "[Hello, world! > Retrieve Message][example]" 
**When** I configure a `Dredd::Rack` runner with `runner.only "Hello, world! > Retrieve Message"` 
**Then** I expect the test to be performed 
**But** no test is run and Dredd exits silently 

See #15 

  [example]: https://github.com/gonzalo-bulnes/dredd-rack-rails-example/blob/v0.2.0/doc/app.apib.md

