### PR TITLE
Add support for Dredd v1.0.8

### DIFF
--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -32,7 +32,11 @@ module Dredd
       BOOLEAN_OPTIONS           = NEGATABLE_BOOLEAN_OPTIONS + META_OPTIONS
 
       SINGLE_ARGUMENT_OPTIONS   = [:hookfiles, :language, :server, :server_wait, :custom, :only,
-                                   :reporter, :output, :header, :user, :method, :level, :path]
+                                   :reporter, :output, :header, :user, :method, :level, :path,
+                                   :hooks_worker_timeout, :hooks_worker_connect_timeout,
+                                   :hooks_worker_connect_retry, :hooks_worker_after_connect_wait,
+                                   :hooks_worker_term_timeout, :hooks_worker_term_retry,
+                                   :hooks_worker_handler_host, :hooks_worker_handler_port]
       OPTIONS                   = BOOLEAN_OPTIONS + SINGLE_ARGUMENT_OPTIONS
 
       # Store the Dredd command line options


### PR DESCRIPTION
**As a** developer 
**In order to** be able to take benefit of Dredd v1.0.8 
**I want** Dredd::Rack to support it 

See apiaryio/dredd@v1.0.7...v1.0.8

Replaces #22 