### PR TITLE
Add dredd_command option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Add **dredd_command** option - with help from @gottfrois
+- Add configuration handler for convenient initializers
+
 ## [0.8.2] - 2016-06-08
 
 ### Fixed
 
-- Fix inaccurate counting of command arguments for local API
+- Fix inaccurate counting of command arguments for local API - @rylnd
 - Minor fix missing documentation for Dredd v1.0.8 options
 
 ## [0.8.1] - 2016-05-07
@@ -72,6 +79,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 The original implementation of the Rake task was shared in this [gist][gist].
 
 [gist]: https://gist.github.com/gonzalo-bulnes/eec3f73cc7d6605add21
+[Unreleased]: https://github.com/gonzalo-bulnes/dredd-rack/compare/v0.8.2...master
 [0.8.2]: https://github.com/gonzalo-bulnes/dredd-rack/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/gonzalo-bulnes/dredd-rack/compare/v0.7.1...v0.8.1
 [0.8.0]: https://github.com/gonzalo-bulnes/dredd-rack/compare/v0.7.1...v0.8.0

--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ Define which application Dredd::Rack must serve automatically:
 
 require 'dredd/rack'
 
-# Allow the automatic setup of a local application server when necessary
-#
-# Find the name of your application in its `config.ru` file.
-Dredd::Rack.app = Example::Application # or Rails.application, Sinatra::Application...
+Dredd::Rack.configure do |config|
+  # Allow the automatic setup of a local application server when necessary
+  #
+  # Find the name of your application in its `config.ru` file.
+  config.app = Example::Application # or Rails.application, Sinatra::Application...
 
-# Optionally, you can define a custom Dredd command:
-Dredd::Rack.dredd_command = 'dredd'
+  # Optionally, you can define a custom Dredd command:
+  config.dredd_command = 'dredd'
+end
+
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ require 'dredd/rack'
 #
 # Find the name of your application in its `config.ru` file.
 Dredd::Rack.app = Example::Application # or Rails.application, Sinatra::Application...
+
+# Optionally, you can define a custom Dredd command:
+Dredd::Rack.dredd_command = 'dredd'
 ```
 
 Usage

--- a/lib/dredd/rack/configuration.rb
+++ b/lib/dredd/rack/configuration.rb
@@ -35,6 +35,10 @@ module Dredd
       @@app = nil
       @@dredd_command = 'dredd'
 
+      # Allow the default configuration to be overwritten from initializers
+      def configure
+        yield self if block_given?
+      end
     end
   end
 end

--- a/lib/dredd/rack/configuration.rb
+++ b/lib/dredd/rack/configuration.rb
@@ -19,8 +19,21 @@ module Dredd
         @@app = object
       end
 
+      # Return the command to be runned to invoke Dredd
+      def dredd_command
+        @@dredd_command
+      end
+
+      # Set a custom Dredd command
+      #
+      # command - the command String
+      def dredd_command=(command)
+        @@dredd_command = command
+      end
+
       # Default configuration
       @@app = nil
+      @@dredd_command = 'dredd'
 
     end
   end

--- a/lib/dredd/rack/rake_task.rb
+++ b/lib/dredd/rack/rake_task.rb
@@ -64,8 +64,7 @@ module Dredd
       private
 
         def dredd_available?
-          `which dredd`
-          $?.exitstatus == 0
+          system ['which', Dredd::Rack.dredd_command].join(' ')
         end
 
         def dredd_connection_error?(exit_status)

--- a/lib/dredd/rack/runner.rb
+++ b/lib/dredd/rack/runner.rb
@@ -49,7 +49,7 @@ module Dredd
       # api_endpoint - the API URL as a String
       #
       def initialize(api_endpoint=nil)
-        @dredd_command = 'dredd'
+        @dredd_command = Dredd::Rack.dredd_command
         @paths_to_blueprints = 'doc/*.apib doc/*.apib.md'
         @api_endpoint = api_endpoint || ''
         @command_parts = []

--- a/spec/lib/dredd/rack/configuration_spec.rb
+++ b/spec/lib/dredd/rack/configuration_spec.rb
@@ -16,12 +16,21 @@ describe Dredd::Rack::Configuration do
 
     let(:subject) { @klass }
 
-    describe 'provides #app which' do
+    describe 'provides .app which' do
 
       it_behaves_like 'a configuration option', 'app'
 
       it "defauts to nil", private: true do
         expect(subject.app).to be_nil
+      end
+    end
+
+    describe 'provides .dredd_command which' do
+
+      it_behaves_like 'a configuration option', 'dredd_command'
+
+      it "defauts to 'dredd'", private: true do
+        expect(subject.dredd_command).to eq 'dredd'
       end
     end
   end


### PR DESCRIPTION
**As a** developer 
**In order to** be able to use Dredd::Rack with installations of Dredd that are not global 
**And**, for example, use it inside a Docker container 
**I want** to define a custom Dredd command 
**And** I want that configuration to be used by all the Rake tasks I define 

See https://github.com/gonzalo-bulnes/dredd-rack/issues/25