### PR TITLE
Support Rake version 11

### DIFF
--- a/dredd-rack.gemspec
+++ b/dredd-rack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files = Dir["spec/**/*"]
 
   gem.add_dependency "capybara", "~> 2.4"
-  gem.add_dependency "rake", "~> 10.4"
+  gem.add_dependency "rake", ">= 10.4"
   gem.add_dependency "rainbow", "~> 2.0"
 
   gem.add_development_dependency "inch", "~> 0.5.10"


### PR DESCRIPTION
There doesn't seem to be any compatibility issues with the 11.x branch of Rake,
and the current dependency specification can cause problems if the gem is included with something that expects a newer version of Rake.