### PR TITLE
Fix missing support for Rake 11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     dredd-rack (0.9.0)
       capybara (~> 2.4)
       rainbow (~> 2.0)
-      rake (>= 10.4, < 11)
+      rake (>= 10.4, < 12)
 
 GEM
   remote: https://rubygems.org/
@@ -41,7 +41,7 @@ GEM
     rack-test (0.6.3)
       rack (>= 1.0)
     rainbow (2.1.0)
-    rake (10.5.0)
+    rake (11.1.2)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)

--- a/dredd-rack.gemspec
+++ b/dredd-rack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files = Dir["spec/**/*"]
 
   gem.add_dependency "capybara", "~> 2.4"
-  gem.add_dependency "rake", ">= 10.4", "< 11"
+  gem.add_dependency "rake", ">= 10.4", "< 12"
   gem.add_dependency "rainbow", "~> 2.0"
 
   gem.add_development_dependency "inch", "~> 0.7.1"


### PR DESCRIPTION
I misspelled the Rake version constraint when enabling support for Rake 11. Oops.

See #31