### PR TITLE
Rake version limitation is removed

### DIFF
--- a/dredd-rack.gemspec
+++ b/dredd-rack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files = Dir["spec/**/*"]
 
   gem.add_dependency "capybara", ">= 2.4", "< 4"
-  gem.add_dependency "rake", ">= 10.4", "< 13"
+  gem.add_dependency "rake", ">= 10.4"
   gem.add_dependency "rainbow", "~> 2.0"
 
   gem.add_development_dependency "inch", "~> 0.7.1"


### PR DESCRIPTION
- it does more harm than good
- rake is very ok with backward compatibility
- it prevents from updating rack to 13